### PR TITLE
Fixing Travis issue when tests are allowed to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ cache:
 
 jobs:
   fast_finish: true
-  allow_failure:
+  allow_failures:
+    - name: "Code Lint Checker"
+  include:
     - name: "Code Lint Checker"
       script: npm run lint
-  include:
     - name: "Automated Tests"
       script: npm run test


### PR DESCRIPTION
Travis is currently running the lint command from eslint and Travis should allow that command to fail since we only want to use it as a warning rather than an error. There is an issue where Travis still marks the build as failed because the lint command failed when Travis should have ignored it.