### PR TITLE
Fix routing in production mode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5387,8 +5387,7 @@
     "connect-history-api-fallback": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
-      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
-      "dev": true
+      "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg=="
     },
     "console-browserify": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "axios": "^0.20.0",
     "chart.js": "^2.9.4",
     "concurrently": "^5.3.0",
+    "connect-history-api-fallback": "^1.6.0",
     "core-js": "^3.7.0",
     "cors": "^2.8.5",
     "epic-spinners": "^1.1.0",

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,0 @@
-const config = {
-	productionPort : 3000
-};//normally 8080 locally
-module.exports = config;

--- a/src/production.js
+++ b/src/production.js
@@ -15,7 +15,5 @@ app.use(history())
 app.use(staticFileMiddleware) 
 // ^ Included twice on purpose
 
-var config = require('./config.js');
-const PORT = config.productionPort;
-//const PORT = 3000//8080
+const PORT = 3000;
 app.listen(PORT, () => console.log(`Frontend server started on port ${PORT}`));

--- a/src/production.js
+++ b/src/production.js
@@ -6,12 +6,15 @@ const cors = require('cors')
 const app = express();
 app.use(cors())
 
-// Setup the frontend if in production (source: https://dennisreimann.de/articles/vue-cli-serve-express.html)
+// Setup the frontend if in production (source: https://forum.vuejs.org/t/how-do-i-implement-connect-history-api-fallback-so-that-url-paths-redirect-to-index-html/10938/2)
 // Since the frontend is only a set of static pages once built we can serve them as static files on a server
 const publicPath = resolve(__dirname, '../dist')
-const staticConf = { maxAge: '1y', etag: false }
-app.use(express.static(publicPath, staticConf))
-app.use('/', history())
+const staticFileMiddleware = express.static(publicPath)
+app.use(staticFileMiddleware)
+app.use(history())
+app.use(staticFileMiddleware) 
+// ^ Included twice on purpose
+
 var config = require('./config.js');
 const PORT = config.productionPort;
 //const PORT = 3000//8080


### PR DESCRIPTION
The routing for production isn't set up properly which meant that refreshing the page or entering a URL directly always resulted in a 404 page (you can try it out on the server and see for yourself). The app only works if you initially enter the application through the root URL (i.e. https://athena.xn--9xa.network) and then navigate using the buttons.

The issue was because the template I followed was outdated so I found a more accurate one which now works as expected.

I have also removed the config file for production since I realized that it is useless since we will only ever run production on the server and don't need to change the port (also the config file was checked in to source control which makes it the same as having it hardcoded anyway).